### PR TITLE
Adding compare operation to country

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -65,6 +65,10 @@ class ISO3166::Country
     other == data
   end
 
+  def <=>(other)
+    self.to_s <=> other.to_s
+  end
+
   def currency
     ISO4217::Currency.from_code(@data['currency'])
   end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -177,8 +177,17 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'compare' do
+    it 'should compare itself with other countries by its name' do
+      canada = ISO3166::Country.search('CA')
+      mexico = ISO3166::Country.search('MX')
+      expect(mexico <=> canada).to eq(1)
+      expect(canada <=> mexico).to eq(-1)
+    end
+  end
+
   describe 'all' do
-    it 'should return an arry list of all countries' do
+    it 'should return an array list of all countries' do
       countries = ISO3166::Country.all
       expect(countries).to be_an(Array)
       expect(countries.first).to be_an(ISO3166::Country)


### PR DESCRIPTION
Fixes error when performing `Country.all.sort` found in admin site:

```
 comparison of ISO3166::Country with ISO3166::Country failed
/Users/guilleart/wepow-app/app/views/admins/organizations/_templates.haml:169:in `sort'
```

@wepow/backend please review
